### PR TITLE
PLAT-436. Fail camus job on MessageDecodeException

### DIFF
--- a/camus-api/pom.xml
+++ b/camus-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-api</artifactId>

--- a/camus-etl-kafka/pom.xml
+++ b/camus-etl-kafka/pom.xml
@@ -5,16 +5,17 @@
 	<parent>
 		<groupId>com.linkedin.camus</groupId>
 		<artifactId>camus-parent</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>0.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camus-etl-kafka</artifactId>
 	<name>Camus ETL to move data from Kafka to Hadoop.</name>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<properties>
 		<!-- skip integration/functional testing by default -->
-        	<skipITs>true</skipITs>
+		<skipITs>true</skipITs>
 	</properties>
 
 	<dependencies>
@@ -37,12 +38,17 @@
 		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro-mapred</artifactId>
-            		<classifier>hadoop2</classifier>
+			<classifier>hadoop2</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-client</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>commons-httpclient</groupId>
+			<artifactId>commons-httpclient</artifactId>
+			<version>${commons-httpclient.version}</version>
+			</dependency>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka_2.9.2</artifactId>
@@ -79,23 +85,23 @@
 	<build>
 		<plugins>
 			<plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.16</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>integration-test</goal>
-                                <goal>verify</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <configuration>
-                        <skipTests>${skipITs}</skipTests>
-                        <systemProperties>
-                        </systemProperties>
-                    </configuration>
-                </plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.16</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<skipTests>${skipITs}</skipTests>
+					<systemProperties>
+					</systemProperties>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
+++ b/camus-etl-kafka/src/main/java/com/linkedin/camus/etl/kafka/common/KafkaReader.java
@@ -51,7 +51,7 @@ public class KafkaReader {
 	 * Construct using the json representation of the kafka request
 	 */
 	public KafkaReader(TaskAttemptContext context, EtlRequest request,
-			int clientTimeout, int fetchBufferSize) throws Exception {
+			int clientTimeout, int fetchBufferSize) throws IOException {
 		this.fetchBufferSize = fetchBufferSize;
 		this.context = context;
 

--- a/camus-example/pom.xml
+++ b/camus-example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-example</artifactId>

--- a/camus-kafka-coders/pom.xml
+++ b/camus-kafka-coders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.linkedin.camus</groupId>
 		<artifactId>camus-parent</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>0.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camus-kafka-coders</artifactId>

--- a/camus-schema-registry-avro/pom.xml
+++ b/camus-schema-registry-avro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-schema-registry-avro</artifactId>

--- a/camus-schema-registry/pom.xml
+++ b/camus-schema-registry/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.linkedin.camus</groupId>
     <artifactId>camus-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camus-schema-registry</artifactId>

--- a/camus-sweeper/pom.xml
+++ b/camus-sweeper/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.linkedin.camus</groupId>
 		<artifactId>camus-parent</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>0.2.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.linkedin.camus</groupId>
 	<artifactId>camus-parent</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Camus Parent</name>
 	<description>
@@ -21,6 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<kafka.version>0.8.1</kafka.version>
 		<avro.version>1.7.4</avro.version>
+		<commons-httpclient.version>3.1</commons-httpclient.version>
 	</properties>
 
         <distributionManagement>


### PR DESCRIPTION
Added parameter for message decode errors threshold. By default it's 0 - camus will fail upon schema error.
Added tests.